### PR TITLE
Fix mobile menu

### DIFF
--- a/src/components/MobileMenu/index.jsx
+++ b/src/components/MobileMenu/index.jsx
@@ -4,7 +4,7 @@ import Menu from 'react-burger-menu/lib/menus/slide'
 
 import './index.scss'
 
-class MobileMenu extends Component {
+export default class MobileMenu extends Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -18,7 +18,6 @@ class MobileMenu extends Component {
     this.setState({ menuOpen: state.isOpen })
   }
 
-  // This is used to close the menu, e.g. when a user clicks a menu item
   closeMenu() {
     this.setState({ menuOpen: false })
   }
@@ -35,35 +34,35 @@ class MobileMenu extends Component {
         <Link
           to="/"
           onClick={() => this.closeMenu()}
-          activeStyle={{ textDecoration: 'underline overline' }}
+          activeStyle={{ textDecoration: 'underline' }}
         >
           Home
         </Link>
         <Link
           to="/harm"
           onClick={() => this.closeMenu()}
-          activeStyle={{ textDecoration: 'underline overline' }}
+          activeStyle={{ textDecoration: 'underline' }}
         >
           Harm
         </Link>
         <Link
           to="/consequences"
           onClick={() => this.closeMenu()}
-          activeStyle={{ textDecoration: 'underline overline' }}
+          activeStyle={{ textDecoration: 'underline' }}
         >
           Consequences
         </Link>
         <Link
           to="/alternatives"
           onClick={() => this.closeMenu()}
-          activeStyle={{ textDecoration: 'underline overline' }}
+          activeStyle={{ textDecoration: 'underline' }}
         >
           Alternatives
         </Link>
         <Link
           to="/request-help"
           onClick={() => this.closeMenu()}
-          activeStyle={{ textDecoration: 'underline overline' }}
+          activeStyle={{ textDecoration: 'underline' }}
         >
           Request Help
         </Link>
@@ -71,5 +70,3 @@ class MobileMenu extends Component {
     )
   }
 }
-
-export default MobileMenu

--- a/src/components/MobileMenu/index.scss
+++ b/src/components/MobileMenu/index.scss
@@ -5,36 +5,11 @@
 /* NOTE: height in pixels has to be divisible by 5
 for the bars to look even */
 div.bm-burger-button {
-  position: fixed;
+  position: absolute;
   width: 25px;
   height: 20px;
   right: 2.6vh;
   top: 3vh;
-}
-
-/* Need to use !important here (for burger button).
-This is to override inline styles from react-burger-menu.
-Expanding the clickable area of the burger button. */
-
-div.bm-burger-button > button {
-  top: -40% !important;
-  bottom: -40% !important;
-  left: -40% !important;
-  right: -40% !important;
-  width: 180% !important;
-  height: 180% !important;
-}
-
-/* Creates a circular background to make burger button visible after scrolling */
-// Width and height here should match div.bm-burger-button width and height
-div.bm-burger-button::after {
-  content: '';
-  width: 25px;
-  height: 20px;
-  background: radial-gradient(circle at center, $blue 50%, transparent 52%);
-  position: absolute;
-  z-index: -1;
-  transform: scale(2.7, 2.7);
 }
 
 /* Color/shape of burger icon bars */
@@ -64,16 +39,6 @@ This is to override inline styles from react-burger-menu. */
   background: $off-white;
   height: 25px !important;
   width: 5px !important;
-}
-
-/* Expanding clickable area for cross button */
-div.bm-cross-button > button {
-  top: -40% !important;
-  bottom: -40% !important;
-  left: -40% !important;
-  right: -40% !important;
-  width: 180% !important;
-  height: 180% !important;
 }
 
 /* General sidebar styles */

--- a/src/pages/alternatives.js
+++ b/src/pages/alternatives.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import classNames from 'classnames'
 import Img from 'gatsby-image'
+import { graphql } from 'gatsby'
 
 import Layout from '../components/layout'
 import PrimaryButton from '../components/PrimaryButton'

--- a/src/pages/consequences.js
+++ b/src/pages/consequences.js
@@ -64,20 +64,21 @@ export default ({ data }) => (
         alt="Text overlay that reads: They said someone in h.r. saw my mugshot on the news. Background image of a man sitting at the bar."
         fluid={data.newsImage.childImageSharp.fluid}
       />
+
       <div className={styles.content}>
         <p>
           Ready to rethink buying sex? There is help available for you now.
         </p>
         
-        <a href="/alternatives" className="arrow-redirect">
+        <a href="/alternatives" className={styles.arrowIcon}>
           <Img
             alt="Image of an ellipse circle with an arrow within it"
             fluid={data.arrowImage.childImageSharp.fluid}
           />
         </a>
         
-        <a href={data.site.siteMetadata.law_link}>
-          <p className={styles.readLaws}>read the laws here</p>
+        <a href={data.site.siteMetadata.law_link} className={styles.readLaws}>
+          read the laws here
         </a>
       </div>
     </div>

--- a/src/pages/consequences.js
+++ b/src/pages/consequences.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Img from 'gatsby-image'
+import { graphql } from 'gatsby'
 
 import Layout from '../components/layout'
 

--- a/src/pages/consequences.module.scss
+++ b/src/pages/consequences.module.scss
@@ -1,6 +1,5 @@
 @import '../assets/shared-styles/shared.module.scss';
-@import '../assets/shared-styles/shared.module.scss';
-
+@import '../assets/shared-styles/colors.module.scss';
 
 .content {
   @extend .contentWrapper;
@@ -18,7 +17,15 @@
     font-size: 1.2rem;
   }
 
+  .arrowIcon {
+    height: 75px;
+    width: 75px;
+    margin: 1rem auto;
+    display: block;
+  }
+
   .readLaws {
+    color: $dark-grey;
     font-family: Cera-Light;
     padding-top: 1em;
   }

--- a/src/pages/harm.js
+++ b/src/pages/harm.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Img from 'gatsby-image'
+import { graphql } from 'gatsby'
 
 import Layout from '../components/layout'
 import alternativesIcon from '../assets/images/alternatives-icon.png'

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,8 +1,10 @@
 import React from 'react'
-import styles from './index.module.scss'
-import sharedStyles from '../assets/shared-styles/shared.module.scss'
+import { graphql } from 'gatsby'
 
 import Layout from '../components/layout'
+
+import styles from './index.module.scss'
+import sharedStyles from '../assets/shared-styles/shared.module.scss'
 
 import harmIcon from '../assets/images/harm-icon.png'
 import consequencesIcon from '../assets/images/consequences-icon.png'

--- a/src/pages/request-help.js
+++ b/src/pages/request-help.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Img from 'gatsby-image'
+import { graphql } from 'gatsby'
 
 import Layout from '../components/layout'
 import GetHelpForm from '../components/GetHelpForm'


### PR DESCRIPTION
Makes hamburger part of hamburger menu stay in the mobile menu header instead of scroll with the screen. Also removes overline and some misc style cleanups; fixes deprecated graphql global use with specific imports